### PR TITLE
added run to logon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # SLS-Discount
 
-**version 1.4.1**
+**version 1.5.0.0**
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,21 @@
-# SLS-Discount
+# SLS-Kassa-Settings-Updater
 
-**version 1.5.0.0**
+**_Current version 1.5.1_**
 
+## ChangeLog
+**version 1.5.1**
+
+Fixed problem with script autorun during user authorization, a relative path was specified instead of a full 
+path to the logs folder, which caused an error if the working folder was not the script folder.
+
+Исправлена проблема с автозапуском скрипта при авторизации пользователя, был указан относительный путь вместо 
+полного к папке логов, что вызывало ошибку, если рабочая папка не была папкой скрипта.
+
+
+**version 1.4.1**
+
+Fixed problem with dataclass(slots=True) in older versions of python for Windows 7, added dataslots() 
+for compatibility.
+
+Исправлена проблема с dataclass(slots=True) в старых версиях Python для Windows 7, добавлены dataslots() 
+для совместимости.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 **_Current version 1.5.1_**
 
+
 ## ChangeLog
+
 **version 1.5.1**
 
 Fixed problem with script autorun during user authorization, a relative path was specified instead of a full 
@@ -19,3 +21,14 @@ for compatibility.
 
 Исправлена проблема с dataclass(slots=True) в старых версиях Python для Windows 7, добавлены dataslots() 
 для совместимости.
+
+
+**version 1.3.0**
+
+Fixed problem with JSON errors in situations where JSON is not correct or the site did not return anything.
+
+The logger settings are moved to a separate file.
+
+Исправлена проблема с ошибками ДЖСОН, в ситуациях, если ДЖСОН не корректен или сайт не вернул ни чего.
+
+Настройки логгера вынесены в отдельный файл.

--- a/add_logon.py
+++ b/add_logon.py
@@ -3,7 +3,7 @@ import sys
 import winreg
 
 
-def set_run_script() -> None:
+def add_to_registry() -> None:
     python_path = os.path.abspath(sys.executable)
     script_path = os.path.dirname(os.path.realpath(__file__))
 
@@ -17,5 +17,5 @@ def set_run_script() -> None:
         "SLS-KassaINI-Updater",
         0,
         winreg.REG_SZ,
-        f'"{python_path}" "{script_path}\\main.py"')
+        f'{python_path} "{script_path}\\main.py"')
     key.Close()

--- a/config.py
+++ b/config.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime
 
 
@@ -6,11 +7,12 @@ date = str(datetime.now().date())
 year = datetime.today().year
 month = f'{datetime.today().month:0{max_number_len}}'
 day = f'{datetime.today().day:0{max_number_len}}'
+script_path = os.path.dirname(os.path.realpath(__file__))
 
 
 # info / debug / or empty
 LOGGER_LEVEL = "info"
-LOGGER_DIR = f'Logs/{year}/{month}/{day}'
+LOGGER_DIR = f'{script_path}/Logs/{year}/{month}/{day}'
 LOGGER_FILE = f'{LOGGER_DIR}/Logs_{date}'
 LOGGER_FORMAT = "%(name)s\t%(asctime)s\t%(levelname)s\t%(message)s"
 

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ py_logger.debug(f"Loading module {__name__}...")
 
 
 def main():
-    version = '1.4.0'
+    version = '1.4.1'
     print(f'Version: {version}{ln()}')
 
     # adding to autostart at user login

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from text_hash import getHash
 from exceptions import CantGetIdentityPC, CantGetJsonFromServer
 from connect_to_server import srv_request
 from getmac import get_mac_address as gma
-from run_with_logon import set_run_script
+from add_logon import add_to_registry
 from set_logger_settings import *
 
 
@@ -14,11 +14,11 @@ py_logger.debug(f"Loading module {__name__}...")
 
 
 def main():
-    version = '1.5.0'
+    version = '1.5.1'
     print(f'Version: {version}{ln()}')
 
     # adding to autostart at user login
-    set_run_script()
+    add_to_registry()
 
     try:
         identity_pc = get_identity_pc()

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ py_logger.debug(f"Loading module {__name__}...")
 
 
 def main():
-    version = '1.4.1'
+    version = '1.5.0'
     print(f'Version: {version}{ln()}')
 
     # adding to autostart at user login

--- a/run-SLS-Kassa-Settings.cmd
+++ b/run-SLS-Kassa-Settings.cmd
@@ -1,3 +1,0 @@
-@echo off
-title run-SLS-Kassa-Settingscd C:\Users\InfSub\Clouds\Git\SLS-Kassa.ini-Settings-Client
-"C:\Users\InfSub\Clouds\Git\SLS-Kassa.ini-Settings-Client\venv\Scripts\python.exe" "main.py"

--- a/run-SLS-Kassa-Settings.cmd
+++ b/run-SLS-Kassa-Settings.cmd
@@ -1,0 +1,3 @@
+@echo off
+title run-SLS-Kassa-Settingscd C:\Users\InfSub\Clouds\Git\SLS-Kassa.ini-Settings-Client
+"C:\Users\InfSub\Clouds\Git\SLS-Kassa.ini-Settings-Client\venv\Scripts\python.exe" "main.py"


### PR DESCRIPTION
**version 1.5.1**

Fixed problem with script autorun during user authorization, a relative path was specified instead of a full 
path to the logs folder, which caused an error if the working folder was not the script folder.
